### PR TITLE
Support Oracle q-Quote Syntax

### DIFF
--- a/syntax/sqloracle.vim
+++ b/syntax/sqloracle.vim
@@ -51,6 +51,13 @@ syn keyword sqlType	mlslabel number raw rowid varchar varchar2 varray
 syn region sqlString	start=+"+  skip=+\\\\\|\\"+  end=+"+
 syn region sqlString	start=+'+  skip=+\\\\\|\\'+  end=+'+
 
+" Quotes:
+syn region sqlQuote	start=+[qQ]'\z([^\[(<{]\)+  end=+\z1'+
+syn region sqlQuote	start=+[qQ]'\[+ end=+\]'+
+syn region sqlQuote	start=+[qQ]'(+  end=+)'+
+syn region sqlQuote	start=+[qQ]'<+  end=+>'+
+syn region sqlQuote	start=+[qQ]'{+  end=+}'+
+
 " Numbers:
 syn match sqlNumber	"-\=\<\d*\.\=[0-9_]\>"
 
@@ -127,6 +134,7 @@ HiLink sqlOperator	sqlStatement
 HiLink sqlSpecial	Special
 HiLink sqlStatement	Statement
 HiLink sqlString	String
+HiLink sqlQuote String
 HiLink sqlType		Type
 HiLink sqlTodo		Todo
 


### PR DESCRIPTION
Oracle supports a quote syntax for defining text that does not require escaping quote characters. It's usually used for defining inline multi-line queries.

Defining as sqlQuote type in syntax file because it seems not to work when it shares with the sqlString. I suspect there's some sort of conflict in those cases.

https://docs.oracle.com/cd/B19306_01/server.102/b14200/sql_elements003.htm#i42617
